### PR TITLE
More cleanup to delay chunk unloads

### DIFF
--- a/patches/server/0009-Delay-chunk-unloads.patch
+++ b/patches/server/0009-Delay-chunk-unloads.patch
@@ -19,7 +19,7 @@ affects player loaded chunks, when we want to target all
 loads.
 
 diff --git a/src/main/java/com/tuinity/tuinity/config/TuinityConfig.java b/src/main/java/com/tuinity/tuinity/config/TuinityConfig.java
-index f10fa659680f8a574f77d260bbc52be349c244e8..233683640827e33107232e10ae2ab35a5141adfe 100644
+index f10fa659680f8a574f77d260bbc52be349c244e8..76dbef9df46d6b80918f80ec7d24bc24f02094b1 100644
 --- a/src/main/java/com/tuinity/tuinity/config/TuinityConfig.java
 +++ b/src/main/java/com/tuinity/tuinity/config/TuinityConfig.java
 @@ -1,6 +1,7 @@
@@ -38,7 +38,7 @@ index f10fa659680f8a574f77d260bbc52be349c244e8..233683640827e33107232e10ae2ab35a
 +    public static int delayChunkUnloadsBy;
 +
 +    private static void delayChunkUnloadsBy() {
-+        delayChunkUnloadsBy = TuinityConfig.getInt("delay-chunkunloads-by", 3) * 20;
++        delayChunkUnloadsBy = TuinityConfig.getInt("delay-chunkunloads-by", 5) * 20;
 +        if (delayChunkUnloadsBy >= 0) {
 +            TicketType.DELAYED_UNLOAD.loadPeriod = delayChunkUnloadsBy;
 +        }
@@ -47,7 +47,7 @@ index f10fa659680f8a574f77d260bbc52be349c244e8..233683640827e33107232e10ae2ab35a
      public static final class WorldConfig {
  
 diff --git a/src/main/java/net/minecraft/server/ChunkMapDistance.java b/src/main/java/net/minecraft/server/ChunkMapDistance.java
-index d3588e238506ea859407b72da0d0cf291945b2ec..da26f56b3922af0076f69e256d7e8f407fdeba5c 100644
+index d3588e238506ea859407b72da0d0cf291945b2ec..f1c686810fb4e9c05df45d664c93af73d17f0624 100644
 --- a/src/main/java/net/minecraft/server/ChunkMapDistance.java
 +++ b/src/main/java/net/minecraft/server/ChunkMapDistance.java
 @@ -31,7 +31,7 @@ public abstract class ChunkMapDistance {
@@ -123,7 +123,7 @@ index d3588e238506ea859407b72da0d0cf291945b2ec..da26f56b3922af0076f69e256d7e8f40
 +            if (ret && ticket.getTicketType().delayUnloadViable && ticket.getTicketLevel() < tempLevel[0]) {
 +                tempLevel[0] = ticket.getTicketLevel();
 +            }
-+            if (ticket.getTicketType() == TicketType.DELAYED_UNLOAD && ticket.isCached) {
++            if (ret && ticket.getTicketType() == TicketType.DELAYED_UNLOAD && ticket.isCached) {
 +                this.delayedChunks.remove(entryPass[0].getLongKey(), ticket); // clean up ticket...
 +            }
 +            return ret;

--- a/patches/server/0011-Lag-compensate-block-breaking.patch
+++ b/patches/server/0011-Lag-compensate-block-breaking.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Lag compensate block breaking
 Use time instead of ticks if ticks fall behind
 
 diff --git a/src/main/java/com/tuinity/tuinity/config/TuinityConfig.java b/src/main/java/com/tuinity/tuinity/config/TuinityConfig.java
-index 233683640827e33107232e10ae2ab35a5141adfe..5069f8aadfaf41e35c22083edf63bd7af1e358b7 100644
+index 76dbef9df46d6b80918f80ec7d24bc24f02094b1..9eb28e3c2b20f6db37aaaae84b7ac28377ddb5d5 100644
 --- a/src/main/java/com/tuinity/tuinity/config/TuinityConfig.java
 +++ b/src/main/java/com/tuinity/tuinity/config/TuinityConfig.java
 @@ -133,6 +133,12 @@ public final class TuinityConfig {

--- a/patches/server/0013-Per-World-Spawn-Limits.patch
+++ b/patches/server/0013-Per-World-Spawn-Limits.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Per World Spawn Limits
 
 
 diff --git a/src/main/java/com/tuinity/tuinity/config/TuinityConfig.java b/src/main/java/com/tuinity/tuinity/config/TuinityConfig.java
-index 5069f8aadfaf41e35c22083edf63bd7af1e358b7..d4c20f4af0588ad1c9a8d0456040cb4e8eb5d0d0 100644
+index 9eb28e3c2b20f6db37aaaae84b7ac28377ddb5d5..3b20b9d64187f95e9244349085aa5a1a890eea62 100644
 --- a/src/main/java/com/tuinity/tuinity/config/TuinityConfig.java
 +++ b/src/main/java/com/tuinity/tuinity/config/TuinityConfig.java
 @@ -269,6 +269,23 @@ public final class TuinityConfig {

--- a/patches/server/0048-Add-packet-limiter-config.patch
+++ b/patches/server/0048-Add-packet-limiter-config.patch
@@ -24,7 +24,7 @@ and an action can be defined: DROP or KICK
 If interval or rate are less-than 0, the limit is ignored
 
 diff --git a/src/main/java/com/tuinity/tuinity/config/TuinityConfig.java b/src/main/java/com/tuinity/tuinity/config/TuinityConfig.java
-index d4c20f4af0588ad1c9a8d0456040cb4e8eb5d0d0..285534d2c9177cd70b3866400171e37db43f77df 100644
+index 3b20b9d64187f95e9244349085aa5a1a890eea62..048139d13424a874364dece8053e248dbcfd4aff 100644
 --- a/src/main/java/com/tuinity/tuinity/config/TuinityConfig.java
 +++ b/src/main/java/com/tuinity/tuinity/config/TuinityConfig.java
 @@ -1,6 +1,7 @@


### PR DESCRIPTION
Bump the default to 5s

Only remove ticket from cached state if it actually expires